### PR TITLE
[server][wmts][fix] updated constant to correct resolution in WMTS ti…

### DIFF
--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -36,7 +36,7 @@ namespace QgsWmts
 
     // Constant
     int tileSize = 256;
-    double POINTS_TO_M = 2.83464567 / 10000.0;
+    double POINTS_TO_M = 2.800005600011068 / 10000.0;
 
     QMap< QString, tileMatrixInfo> fixedTileMatrixInfoMap = populateFixedTileMatrixInfoMap();
     QMap< QString, tileMatrixInfo> calculatedTileMatrixInfoMap; // for project without WMTSGrids configuration


### PR DESCRIPTION
…le grid initialization

Constant needed to be updated in order to match the standard rendering pixel size of 0.28mm x 0.28mm defined by the OGC resulting in DPI of 90.71428571429.

Should fix #34826, #42942, #39040 